### PR TITLE
Add GHA to create a WowUp compatible release on tag

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,17 @@
+name: Package and release
+on:
+  push:
+    tags:
+      - "**"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Package and release
+        uses: BigWigsMods/packager@v2

--- a/PersonalLootHelper-Config.lua
+++ b/PersonalLootHelper-Config.lua
@@ -13,13 +13,14 @@ function PLH_CreateOptionsPanel()
 
 	-- [[ Version ]] --
 	local versionLabel = configFrame:CreateFontString(nil, 'ARTWORK', 'GameFontNormalSmall')
+	local metaVersion = GetAddOnMetadata('PersonalLootHelper', 'Version')
 	versionLabel:SetPoint('BOTTOMLEFT', titleLabel, 'BOTTOMRIGHT', 8, 0)
-	versionLabel:SetText('v' .. GetAddOnMetadata('PersonalLootHelper', 'Version'))
+	versionLabel:SetText(((metaVersion:find("^v") ~= nil) and "" or "v") .. metaVersion)
 
 	--[[ Author ]]--
 	local authorLabel = configFrame:CreateFontString(nil, 'ARTWORK', 'GameFontNormalSmall')
 	authorLabel:SetPoint('TOPRIGHT', configFrame, 'TOPRIGHT', -16, -24)
-	authorLabel:SetText("Author: Madone-Zul'Jin")
+	authorLabel:SetText(GetAddOnMetadata('PersonalLootHelper', 'Author'))
 
 	--[[ Display Options ]]--
 	local displayLabel = configFrame:CreateFontString(nil, 'ARTWORK', 'GameFontHighlight')

--- a/PersonalLootHelper.toc
+++ b/PersonalLootHelper.toc
@@ -1,9 +1,9 @@
 ## Interface: 100200
 ## Title: Personal Loot Helper
-## Version: 2.29
+## Version: @project-version@
 ## SavedVariables: PLH_META, PLH_PREFS, PLH_STATS
 ## Notes: Simplifies trading of personal loot with other group members.
-## Author: Madone-Zul'Jin
+## Author: Madone-Zul'Jin (voidzone fork)
 
 libs\LibStub\LibStub.lua
 libs\MSA-DropDownMenu-1.0\MSA-DropDownMenu-1.0.xml

--- a/PersonalLootHelper.toc
+++ b/PersonalLootHelper.toc
@@ -3,7 +3,7 @@
 ## Version: @project-version@
 ## SavedVariables: PLH_META, PLH_PREFS, PLH_STATS
 ## Notes: Simplifies trading of personal loot with other group members.
-## Author: Madone-Zul'Jin (voidzone fork)
+## Author: Madone-Zul'Jin (voidzone@github's fork)
 
 libs\LibStub\LibStub.lua
 libs\MSA-DropDownMenu-1.0\MSA-DropDownMenu-1.0.xml


### PR DESCRIPTION
As-per https://github.com/WowUp/WowUp/issues/1245, WowUp requires specific releases to be able to update plugins directly from GitHub.

This implements  that logic - just create and push a tag on a commit, it'll create and push a release, then WowUp users will be able to keep this fork up to date automatically.

Additionally, automatically update .toc file with version from tag