### PR TITLE
fix: GetLootMethod comparison

### DIFF
--- a/PersonalLootHelper-Core.lua
+++ b/PersonalLootHelper-Core.lua
@@ -2476,7 +2476,7 @@ end
 
 local function EnableOrDisable()
 	local inInstance, instanceType = IsInInstance()
-	local isPersonalLoot = (IsInGroup(LE_PARTY_CATEGORY_INSTANCE) or (IsInGroup() and C_PartyInfo.GetLootMethod() == 'personalloot'))
+	local isPersonalLoot = (IsInGroup(LE_PARTY_CATEGORY_INSTANCE) or (IsInGroup() and C_PartyInfo.GetLootMethod() == Enum.LootMethod.Personal))
 		and (instanceType == "party" or instanceType == "raid")
 	local shouldBeEnabled = isPersonalLoot
 


### PR DESCRIPTION
Fixes: https://github.com/voidzone/PersonalLootHelper/issues/8

After some debugging i found out that C_PartyInfo.GetLootMethod() returns 5 nil nil in a dungeon group and therefore PLH never called Enable() for me.

For reference from the wow api:

```

			Name = "LootMethod",
			Type = "Enumeration",
			NumValues = 6,
			MinValue = 0,
			MaxValue = 5,
			Fields =
			{
				{ Name = "Freeforall", Type = "LootMethod", EnumValue = 0 },
				{ Name = "Roundrobin", Type = "LootMethod", EnumValue = 1 },
				{ Name = "Masterlooter", Type = "LootMethod", EnumValue = 2 },
				{ Name = "Group", Type = "LootMethod", EnumValue = 3 },
				{ Name = "Needbeforegreed", Type = "LootMethod", EnumValue = 4 },
				{ Name = "Personal", Type = "LootMethod", EnumValue = 5 },
			},
		},
```

There isn't even a personalloot anymore.